### PR TITLE
Fix type detection issues

### DIFF
--- a/Source/ModManager.cpp
+++ b/Source/ModManager.cpp
@@ -1510,7 +1510,7 @@ const std::array<wxString, 8> ModManager::dataFiles_ =
 		"shkres.res",
 		"skeldata.res",
 		"texture.res",
-		"*.nut"
+		"*.nut",
 		"*.osm"
 	}
 };

--- a/Source/ModManager.cpp
+++ b/Source/ModManager.cpp
@@ -1474,11 +1474,14 @@ void ModManager::resetStates()
 	}
 }
 
-const std::array<wxString, 18> ModManager::dataDirectories_ =
+const std::array<wxString, 21> ModManager::dataDirectories_ =
 {
 	{
 		"bitmap",
 		"book",
+		"books",
+		"camera",
+		"default",
 		"editor",
 		"fam",
 		"fonts",

--- a/Source/ModManager.hpp
+++ b/Source/ModManager.hpp
@@ -106,7 +106,7 @@ private:
 	void collectMisFileToModMapping(Mod& mod, std::unordered_map<std::string, std::vector<Mod*>>& misFileToMods);
 	void createLogFile();
 
-	static const std::array<wxString, 18> dataDirectories_;
+	static const std::array<wxString, 21> dataDirectories_;
 	static const std::array<wxString, 8> dataFiles_;
 
 	ApplicationConfig& config_;


### PR DESCRIPTION
Hi, pshjt.

This pull request should correct a couple of small issues with the mod type detection. In particular, some of the Thief-only resource directory names are missing, with the most important of these being "books". More significantly, the resource file detection does not currently work for script files due to a single missing comma, which causes the final two members of the list to be concatenated instead. This can cause some resource mods to be unrecognized despite being valid.

On another note, I see that there is now also a "Script" mod type, though it will seemingly only be applied for SCP due to it supplying the requisite "scriptdata" directory. I did not include this change since this may be intentional, but it would probably make sense to have OSMs and Squirrel scripts be detected using this category rather than as generic resources.