### PR TITLE
Use the Script mod type for mods including native and Squirrel scripts

### DIFF
--- a/Source/ModManager.cpp
+++ b/Source/ModManager.cpp
@@ -1100,7 +1100,7 @@ void ModManager::checkModDirectory(Mod& mod)
 	}
 	mod.setHasSubtitle(dir.HasSubDirs(config_.game.subtitleFolder));
 	mod.setHasDML(dir.HasFiles("*.dml") || dir.HasSubDirs("dbmods"));
-	mod.setHasScript(dir.HasSubDirs("scriptdata"));
+	mod.setHasScript(dir.HasFiles("*.osm") || dir.HasSubDirs("sq_scripts") || dir.HasSubDirs("scriptdata"));
 	mod.setHasMis(dir.HasFiles("*.mis"));
 	mod.setHasGamesys(dir.HasFiles("*.gam"));
 	mod.setHasOther(dir.HasFiles("*.crf"));
@@ -1474,7 +1474,7 @@ void ModManager::resetStates()
 	}
 }
 
-const std::array<wxString, 21> ModManager::dataDirectories_ =
+const std::array<wxString, 20> ModManager::dataDirectories_ =
 {
 	{
 		"bitmap",
@@ -1496,12 +1496,11 @@ const std::array<wxString, 21> ModManager::dataDirectories_ =
 		"snd",
 		"snd2",
 		"song",
-		"sq_scripts",
 		"strings"
 	}
 };
 
-const std::array<wxString, 8> ModManager::dataFiles_ =
+const std::array<wxString, 6> ModManager::dataFiles_ =
 {
 	{
 		"motiondb.bin",
@@ -1509,8 +1508,6 @@ const std::array<wxString, 8> ModManager::dataFiles_ =
 		"metaui_r.res",
 		"shkres.res",
 		"skeldata.res",
-		"texture.res",
-		"*.nut",
-		"*.osm"
+		"texture.res"
 	}
 };

--- a/Source/ModManager.hpp
+++ b/Source/ModManager.hpp
@@ -106,8 +106,8 @@ private:
 	void collectMisFileToModMapping(Mod& mod, std::unordered_map<std::string, std::vector<Mod*>>& misFileToMods);
 	void createLogFile();
 
-	static const std::array<wxString, 21> dataDirectories_;
-	static const std::array<wxString, 8> dataFiles_;
+	static const std::array<wxString, 20> dataDirectories_;
+	static const std::array<wxString, 6> dataFiles_;
 
 	ApplicationConfig& config_;
 	ModConfig modConfig_;


### PR DESCRIPTION
This PR should move script detection fully into its own mod category rather than having scripts detected as generic resources, encompassing all native scripts (OSMs) in the root mod directory and all Squirrel scripts in the `sq_scripts` subdirectory.

It's also worth noting that loose Squirrel script files in the root directory should preferably not be detected. The Squirrel module exclusively looks in `sq_scripts` for scripts upon being loaded, so any that are located elsewhere will always be ignored. While the native script directory paths are configurable with the `script_module_path` variable, all mods currently (and likely ought to continue to) assume that only the root directory is a valid location.